### PR TITLE
[👌 IMPROVE] Makefile: .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 # Project and compiler information
-NAME=zps
-CFLAGS=-s -O3 -Wall
-CC=gcc
+NAME := zps
+CFLAGS := -s -O3 -Wall -Wextra -pedantic
+ifeq ($(CC),)
+    CC := gcc
+endif
 all: clean build
 # Build the project
 build:

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,5 @@ install:
 # Clean
 clean:
 	rm -rf build
+
+.PHONY: all build install clean


### PR DESCRIPTION
Without the `build` rule added to `.PHONY`, when running `make` sequentially, it alternatively runs `build + clean` and only `clean`. The second time, it sees that the `build` directory is already built so it skips it, like in the screenshot:

![image](https://user-images.githubusercontent.com/6838492/67949256-1a17c900-fbf0-11e9-8232-e410bafcac2d.png)

Might as well add all the other rules to `.PHONY`.