### PR TITLE
Remove Version key

### DIFF
--- a/.application/zps.desktop
+++ b/.application/zps.desktop
@@ -3,9 +3,6 @@
 # Type
 Type=Application
 
-# Latest version
-Version=1.2.5
-
 # The name of the application
 Name=zps
 


### PR DESCRIPTION
The `Version` key is not supposed to be the application version, but the Desktop Entry Specification version (which is currently 1.5). As per the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html), it is safe to remove it:

> Note that the version field is not required to be present.

You can check the `zps.desktop` file with the `desktop-file-validate` utility:

```
zps.desktop: error: value "1.2.5" for key "Version" in group "Desktop Entry" is not a known version
```

Unrelated suggestion: since zps is a console application, it would be nice if the zps.desktop file had a `NoDisplay=true` entry. On my Fedora 34 Workstation, zps is an application without an icon (utilities-system-monitor does not exist here).

![icon](https://user-images.githubusercontent.com/66979446/123535168-9c73cb80-d6f8-11eb-85f0-13b51f2d428b.png)
