### PR TITLE
Fix memory leaks

### DIFF
--- a/src/zps.c
+++ b/src/zps.c
@@ -187,9 +187,10 @@ static int formatStatContent(char *statContent) {
             }
             /* Update the original file content and deallocate the memory. */
             strcpy(statContent, contentDup);
-            free(contentDup);
         }
+        free(contentDup);
     }
+    regfree(&regex);
     return EXIT_SUCCESS;
 }
 

--- a/src/zps.h
+++ b/src/zps.h
@@ -15,6 +15,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef ZPS_H
+#define ZPS_H
+
 #define VERSION "1.2.8"            /* Version */
 #define _XOPEN_SOURCE 700          /* POSIX.1-2008 + XSI (SuSv4) */
 #define _LARGEFILE64_SOURCE        /* Enable LFS */
@@ -32,3 +35,5 @@
 #define CLR_DEFAULT "\x1b[0m"      /* Default color and style attributes */
 #define CLR_BOLD "\x1b[1m"         /* Bold attribute */
 #define CLR_RED "\x1b[31m"         /* Color red */
+
+#endif // ZPS_H


### PR DESCRIPTION
The program in its current state leaks memory from the `formatStatContent` function during its execution.

Instrumenting the binary with Valgrind's `memcheck` tool exposes the oversight:
```
$ valgrind -s --tool=memcheck --leak-check=full --show-leak-kinds=all $(which zps)
[...]
==30228== LEAK SUMMARY:
==30228==    definitely lost: 95,653 bytes in 382 blocks
==30228==    indirectly lost: 1,319,712 bytes in 8,369 blocks
==30228==      possibly lost: 0 bytes in 0 blocks
==30228==    still reachable: 11,136 bytes in 69 blocks
==30228==         suppressed: 0 bytes in 0 blocks
==30228== 
==30228== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```

Running the program compiled using `gcc` with `-fsanitize=address -fsanitize=leak -fsanitize=undefined` also would have shown the presence of leaked memory.

The origins of the leaks are calls to `regcomp` and `strdup` without being followed by their appropriate deallocating calls (`regfree` and `free`, respectively).

The commit c11d77116d58578ea52757381241f34b443a2e25 fixes this by:

* putting the `free` outside of the `if` statement's block, as it should be unconditional
* inserting the `regfree` call before returning

With these patches applied, the program runs like this:
```
$ valgrind -s --tool=memcheck --leak-check=full --show-leak-kinds=all ./zps
[...]
==31351== HEAP SUMMARY:
==31351==     in use at exit: 0 bytes in 0 blocks
==31351==   total heap usage: 16,183 allocs, 16,183 frees, 105,154,201 bytes allocated
==31351== 
==31351== All heap blocks were freed -- no leaks are possible
==31351== 
==31351== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

Commit cb619439a9e297c184fb27114675e7ffe1c90cb2 simply adds `#include` guards to the header to avoid redefinitions.